### PR TITLE
Apply Claude/Anthropic-inspired design system — cream canvas, coral C…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#0F2040" />
+  <meta name="theme-color" content="#faf9f5" />
   <meta name="description" content="MSKAssociates — Trusted Structural Engineers, Planners & Builders in Hanamakonda, Telangana. Residential, commercial and industrial projects designed safe, built to last." />
   <meta name="keywords" content="structural engineers Hanamakonda, construction Warangal, structural planning Telangana, MSK Associates, builders Hanamakonda" />
   <meta name="author" content="MSKAssociates" />
@@ -37,7 +37,7 @@
   <link rel="preload" as="image" href="https://images.unsplash.com/photo-1508450859948-4e04fabaa4ea?w=1920&q=90&auto=format&fit=crop" />
 
   <!-- Fonts + Tailwind -->
-  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garant:ital,wght@0,600;0,700;1,600&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 
   <title>MSKAssociates — Structural Engineers, Planners & Builders</title>
 </head>

--- a/src/App.js
+++ b/src/App.js
@@ -83,10 +83,10 @@ function WizardModal({ onClose, onOpen }) {
             position: 'sticky', top: 0, backgroundColor: 'white', zIndex: 1,
           }}>
             <div>
-              <p style={{ fontSize: '0.6rem', color: '#C1440E', fontFamily: 'Inter', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: '3px' }}>
+              <p style={{ fontSize: '0.6rem', color: '#cc785c', fontFamily: 'Inter', fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: '3px' }}>
                 Project Planner
               </p>
-              <p style={{ fontSize: '1.05rem', fontWeight: 800, color: '#0F2040', fontFamily: 'Inter', lineHeight: 1.2 }}>
+              <p style={{ fontSize: '1.05rem', fontWeight: 500, color: '#141413', fontFamily: 'Inter', lineHeight: 1.2 }}>
                 What does your project need?
               </p>
             </div>
@@ -100,7 +100,7 @@ function WizardModal({ onClose, onOpen }) {
                 color: '#9ca3af', fontSize: '1rem', flexShrink: 0,
                 transition: 'border-color 0.15s, color 0.15s',
               }}
-              onMouseEnter={e => { e.currentTarget.style.borderColor = '#C1440E'; e.currentTarget.style.color = '#C1440E'; }}
+              onMouseEnter={e => { e.currentTarget.style.borderColor = '#cc785c'; e.currentTarget.style.color = '#cc785c'; }}
               onMouseLeave={e => { e.currentTarget.style.borderColor = '#e5e7eb'; e.currentTarget.style.color = '#9ca3af'; }}
             >
               ✕
@@ -129,7 +129,7 @@ function App() {
     return (
       <div className="fixed inset-0 bg-white flex flex-col items-center justify-center z-50">
         <img src="/Images/logos/logo-light.png" alt="MSK Associates" style={{ height: '80px', width: 'auto', marginBottom: '1.5rem' }} />
-        <div className="w-8 h-8 border-4 rounded-full animate-spin" style={{borderColor:'#C1440E', borderTopColor:'transparent'}} />
+        <div className="w-8 h-8 border-4 rounded-full animate-spin" style={{borderColor:'#cc785c', borderTopColor:'transparent'}} />
       </div>
     );
   }

--- a/src/Components/AboutUs.js
+++ b/src/Components/AboutUs.js
@@ -15,25 +15,25 @@ const fadeUp = {
 };
 
 const AboutUs = () => (
-  <div style={{ backgroundColor: '#FAFAF8' }}>
+  <div style={{ backgroundColor: '#faf9f5' }}>
     <div className="max-w-7xl mx-auto px-6 lg:px-14" style={{ paddingTop: '7rem', paddingBottom: '7rem' }}>
 
       <motion.p
         initial="hidden" whileInView="visible" viewport={{ once: true, amount: 0.4 }} variants={fadeUp}
         style={{
           display: 'flex', alignItems: 'center', gap: '0.8rem',
-          fontSize: '0.58rem', color: '#C1440E', fontWeight: 700,
+          fontSize: '0.58rem', color: '#cc785c', fontWeight: 500,
           textTransform: 'uppercase', letterSpacing: '0.22em',
           fontFamily: 'Inter, sans-serif', marginBottom: '5rem',
         }}
       >
-        <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#C1440E' }} />
+        <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#cc785c' }} />
         About MSK Associates
       </motion.p>
 
       <div className="grid lg:grid-cols-2 gap-16 lg:gap-28 items-center" style={{ marginBottom: '6rem' }}>
         <motion.div initial="hidden" whileInView="visible" viewport={{ once: true, amount: 0.3 }} variants={fadeLeft}>
-          <div style={{ position: 'relative', borderRadius: '4px', overflow: 'hidden' }}>
+          <div style={{ position: 'relative', borderRadius: '12px', overflow: 'hidden' }}>
             <img
               src="https://images.unsplash.com/photo-1563166423-482a8c14b2d6?w=900&q=90&auto=format&fit=crop"
               alt="MSK Associates structural engineering site work"
@@ -46,16 +46,16 @@ const AboutUs = () => (
 
         <motion.div initial="hidden" whileInView="visible" viewport={{ once: true, amount: 0.3 }} variants={fadeRight}>
           <h2 style={{
-            fontFamily: 'Cormorant Garant, Georgia, serif',
+            fontFamily: 'Cormorant Garamond, Georgia, serif',
             fontSize: 'clamp(2.4rem, 4.5vw, 3.6rem)',
-            fontWeight: 700, lineHeight: 1.0,
-            letterSpacing: '-0.025em', color: '#1a1714',
+            fontWeight: 500, lineHeight: 1.0,
+            letterSpacing: '-0.025em', color: '#141413',
             marginBottom: '2rem',
           }}>
             Pioneering with<br />Precision.
           </h2>
-          <div style={{ width: '40px', height: '2px', backgroundColor: '#C1440E', marginBottom: '2rem' }} />
-          <div style={{ color: '#666', lineHeight: 1.9, fontSize: '0.95rem', fontFamily: 'Inter, sans-serif' }}
+          <div style={{ width: '40px', height: '2px', backgroundColor: '#cc785c', marginBottom: '2rem' }} />
+          <div style={{ color: '#3d3d3a', lineHeight: 1.9, fontSize: '0.95rem', fontFamily: 'Inter, sans-serif' }}
             className="space-y-5">
             <p>MSK Associates is a focused structural engineering firm based in Warangal — delivering residential, commercial, and industrial projects across Telangana.</p>
             <p>We handle the full scope: residential homes, multi-storey complexes, industrial structures, and layout planning. Every project goes through the same process — drawings, statutory stamping, site visits at every critical milestone.</p>
@@ -68,36 +68,36 @@ const AboutUs = () => (
         initial="hidden" whileInView="visible" viewport={{ once: true, amount: 0.3 }} variants={fadeUp}
         style={{
           position: 'relative', overflow: 'hidden',
-          backgroundColor: '#EDEAE3',
-          borderRadius: '4px',
-          borderLeft: '4px solid #C1440E',
+          backgroundColor: '#f5f0e8',
+          borderRadius: '12px',
+          borderLeft: '4px solid #cc785c',
           padding: 'clamp(2.5rem, 5vw, 4rem) clamp(2rem, 5vw, 4rem)',
-          boxShadow: '0 2px 24px rgba(26,23,20,0.06)',
+          boxShadow: '0 2px 24px rgba(20,20,19,0.06)',
         }}
       >
         <span style={{
           position: 'absolute', top: '-2rem', left: '1.5rem',
           fontSize: '16rem', lineHeight: 1,
-          color: 'rgba(193,68,14,0.07)', fontFamily: 'Georgia, serif',
+          color: 'rgba(204,120,92,0.07)', fontFamily: 'Georgia, serif',
           userSelect: 'none', pointerEvents: 'none',
         }}>"</span>
         <div style={{ position: 'relative' }}>
           <p style={{
-            fontFamily: 'Cormorant Garant, Georgia, serif',
+            fontFamily: 'Cormorant Garamond, Georgia, serif',
             fontSize: 'clamp(1.5rem, 3vw, 2.2rem)',
             fontStyle: 'italic', lineHeight: 1.55,
-            color: '#1a1714', maxWidth: '780px', marginBottom: '2rem',
+            color: '#141413', maxWidth: '780px', marginBottom: '2rem',
             letterSpacing: '-0.01em',
           }}>
             "I started MSK Associates with one belief — that the engineer who designs your structure should also be the one who stands on your site."
           </p>
-          <p style={{ color: '#6b6460', fontSize: '0.92rem', lineHeight: 1.85, maxWidth: '640px', marginBottom: '2.5rem', fontFamily: 'Inter, sans-serif' }}>
+          <p style={{ color: '#3d3d3a', fontSize: '0.92rem', lineHeight: 1.85, maxWidth: '640px', marginBottom: '2.5rem', fontFamily: 'Inter, sans-serif' }}>
             With over 10 years of experience across residential, commercial, and industrial projects in Telangana, I built MSK Associates on one principle — personal accountability on every project. When you work with us, you work directly with me — from the first calculation to the final inspection.
           </p>
-          <div style={{ borderTop: '1px solid #d0cbc2', paddingTop: '1.75rem', display: 'flex', alignItems: 'center', gap: '1rem' }}>
-            <div style={{ width: '28px', height: '2px', backgroundColor: '#C1440E', flexShrink: 0 }} />
+          <div style={{ borderTop: '1px solid #e6dfd8', paddingTop: '1.75rem', display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <div style={{ width: '28px', height: '2px', backgroundColor: '#cc785c', flexShrink: 0 }} />
             <div>
-              <p style={{ fontWeight: 700, color: '#1a1714', fontSize: '0.9rem', fontFamily: 'Inter, sans-serif' }}>Er. Myana Sai Krishna</p>
+              <p style={{ fontWeight: 500, color: '#141413', fontSize: '0.9rem', fontFamily: 'Inter, sans-serif' }}>Er. Myana Sai Krishna</p>
               <p style={{ color: '#9ca3af', fontSize: '0.75rem', marginTop: '3px', fontFamily: 'Inter, sans-serif' }}>ME (Structures), AMIE · Founder, MSK Associates</p>
             </div>
           </div>

--- a/src/Components/CallToAction.js
+++ b/src/Components/CallToAction.js
@@ -11,7 +11,7 @@ const items = [
 ];
 
 const CallToAction = () => (
-  <div style={{ backgroundColor: '#FAFAF8', borderTop: '1px solid #e0dbd2' }}>
+  <div style={{ backgroundColor: '#faf9f5', borderTop: '1px solid #e6dfd8' }}>
     <div
       className="max-w-7xl mx-auto px-6 lg:px-14 cta-grid"
       style={{
@@ -32,24 +32,24 @@ const CallToAction = () => (
       >
         <p style={{
           display: 'flex', alignItems: 'center', gap: '0.8rem',
-          fontSize: '0.58rem', color: '#C1440E', fontWeight: 700,
+          fontSize: '0.58rem', color: '#cc785c', fontWeight: 500,
           textTransform: 'uppercase', letterSpacing: '0.22em',
           fontFamily: 'Inter, sans-serif', marginBottom: '1.2rem',
         }}>
-          <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#C1440E' }} />
+          <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#cc785c' }} />
           Our Capabilities
         </p>
         <h2 className="cta-heading" style={{
-          fontFamily: 'Cormorant Garant, Georgia, serif',
+          fontFamily: 'Cormorant Garamond, Georgia, serif',
           fontSize: 'clamp(2.2rem, 3.8vw, 3.4rem)',
-          fontWeight: 700, lineHeight: 1.0,
-          letterSpacing: '-0.025em', color: '#1a1714',
+          fontWeight: 500, lineHeight: 1.0,
+          letterSpacing: '-0.025em', color: '#141413',
           margin: '0 0 1.8rem',
         }}>
           Every service<br />your project needs.
         </h2>
         <p style={{
-          color: '#888', lineHeight: 1.85, fontSize: '0.88rem',
+          color: '#6c6a64', lineHeight: 1.85, fontSize: '0.88rem',
           fontFamily: 'Inter, sans-serif', margin: '0 0 2rem',
           maxWidth: '320px',
         }}>
@@ -57,22 +57,22 @@ const CallToAction = () => (
         </p>
         <a href="#contact" style={{
           display: 'inline-block',
-          backgroundColor: '#C1440E', color: '#fff',
-          borderRadius: '3px', padding: '13px 32px',
-          fontSize: '0.75rem', fontWeight: 700,
+          backgroundColor: '#cc785c', color: '#fff',
+          borderRadius: '8px', padding: '13px 32px',
+          fontSize: '0.75rem', fontWeight: 500,
           fontFamily: 'Inter, sans-serif', letterSpacing: '0.07em',
           textTransform: 'uppercase', textDecoration: 'none',
           transition: 'transform 0.22s ease, box-shadow 0.22s ease, background-color 0.22s ease',
         }}
-          onMouseEnter={e => { e.currentTarget.style.transform = 'translateY(-2px)'; e.currentTarget.style.boxShadow = '0 14px 36px rgba(193,68,14,0.3)'; e.currentTarget.style.backgroundColor = '#a8390b'; }}
-          onMouseLeave={e => { e.currentTarget.style.transform = ''; e.currentTarget.style.boxShadow = ''; e.currentTarget.style.backgroundColor = '#C1440E'; }}
+          onMouseEnter={e => { e.currentTarget.style.transform = 'translateY(-2px)'; e.currentTarget.style.boxShadow = '0 14px 36px rgba(204,120,92,0.3)'; e.currentTarget.style.backgroundColor = '#a9583e'; }}
+          onMouseLeave={e => { e.currentTarget.style.transform = ''; e.currentTarget.style.boxShadow = ''; e.currentTarget.style.backgroundColor = '#cc785c'; }}
         >
           Get in Touch →
         </a>
       </motion.div>
 
       {/* Right — compact service list */}
-      <div style={{ borderTop: '1px solid #e0dbd2' }}>
+      <div style={{ borderTop: '1px solid #e6dfd8' }}>
         {items.map((title, i) => (
           <motion.div
             key={title}
@@ -82,21 +82,21 @@ const CallToAction = () => (
             style={{
               display: 'flex', alignItems: 'center', justifyContent: 'space-between',
               padding: '1.35rem 0',
-              borderBottom: '1px solid #e0dbd2',
+              borderBottom: '1px solid #e6dfd8',
               gap: '1rem',
             }}
           >
             <p style={{
-              fontFamily: 'Cormorant Garant, Georgia, serif',
+              fontFamily: 'Cormorant Garamond, Georgia, serif',
               fontSize: 'clamp(1.1rem, 1.8vw, 1.4rem)',
-              fontWeight: 600, color: '#1a1714',
+              fontWeight: 600, color: '#141413',
               letterSpacing: '-0.01em', lineHeight: 1.2,
               margin: 0,
             }}>{title}</p>
             <span style={{
               flexShrink: 0,
               width: '20px', height: '1px',
-              backgroundColor: '#C1440E',
+              backgroundColor: '#cc785c',
               display: 'inline-block',
             }} />
           </motion.div>

--- a/src/Components/Contact.js
+++ b/src/Components/Contact.js
@@ -19,16 +19,16 @@ const INFO = [
 const inputStyle = {
   display: 'block', width: '100%',
   padding: '12px 0', background: 'transparent',
-  border: 'none', borderBottom: '1.5px solid #c8c4bc',
-  fontSize: '0.95rem', color: '#1a1714',
+  border: 'none', borderBottom: '1.5px solid #e6dfd8',
+  fontSize: '0.95rem', color: '#141413',
   fontFamily: 'Inter, sans-serif', outline: 'none',
   boxSizing: 'border-box', transition: 'border-color 0.2s',
 };
 
 const labelStyle = {
   display: 'block', marginBottom: '6px',
-  fontSize: '0.6rem', fontWeight: 700,
-  color: '#9ca3af', textTransform: 'uppercase',
+  fontSize: '0.6rem', fontWeight: 500,
+  color: '#8e8b82', textTransform: 'uppercase',
   letterSpacing: '0.13em', fontFamily: 'Inter, sans-serif',
 };
 
@@ -100,21 +100,21 @@ export default function Contact() {
       `}</style>
 
       {/* ── Left panel — dark navy ─────────────────────────────── */}
-      <div className="contact-left" style={{ backgroundColor: '#1a1714', padding: 'clamp(3rem, 6vw, 5rem)', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+      <div className="contact-left" style={{ backgroundColor: '#181715', padding: 'clamp(3rem, 6vw, 5rem)', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
         <div>
-          <p style={{ fontSize: '0.58rem', fontWeight: 700, color: '#C1440E', textTransform: 'uppercase', letterSpacing: '0.18em', fontFamily: 'Inter, sans-serif', marginBottom: '2rem' }}>
+          <p style={{ fontSize: '0.58rem', fontWeight: 500, color: '#cc785c', textTransform: 'uppercase', letterSpacing: '0.18em', fontFamily: 'Inter, sans-serif', marginBottom: '2rem' }}>
             Based in Warangal, Telangana
           </p>
-          <h2 style={{ fontSize: 'clamp(2.6rem, 4.5vw, 3.8rem)', fontWeight: 800, color: '#fff', lineHeight: 1.0, fontFamily: 'Cormorant Garant, Georgia, serif', marginBottom: '2rem', letterSpacing: '-0.01em' }}>
+          <h2 style={{ fontSize: 'clamp(2.6rem, 4.5vw, 3.8rem)', fontWeight: 500, color: '#fff', lineHeight: 1.0, fontFamily: 'Cormorant Garamond, Georgia, serif', marginBottom: '2rem', letterSpacing: '-0.01em' }}>
             Let's talk<br />about your<br />project.
           </h2>
-          <p style={{ color: '#6b7280', fontSize: '0.88rem', lineHeight: 1.85, fontFamily: 'Inter, sans-serif', marginBottom: '3.5rem', maxWidth: '300px' }}>
+          <p style={{ color: '#a09d96', fontSize: '0.88rem', lineHeight: 1.85, fontFamily: 'Inter, sans-serif', marginBottom: '3.5rem', maxWidth: '300px' }}>
             Tell us what you're building. We respond within one business day — usually the same afternoon.
           </p>
 
           {/* Trust line */}
           <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '1.75rem', marginBottom: '2.5rem' }}>
-            <p style={{ fontSize: '0.78rem', color: '#9ca3af', fontFamily: 'Inter, sans-serif', lineHeight: 1.7 }}>
+            <p style={{ fontSize: '0.78rem', color: '#a09d96', fontFamily: 'Inter, sans-serif', lineHeight: 1.7 }}>
               Hundreds of projects delivered across Telangana.<br />Every drawing stamped. Every site supervised.
             </p>
           </div>
@@ -126,7 +126,7 @@ export default function Contact() {
               { v: 'designs@mskassociates.com' },
               { v: 'Mon – Fri, 9 AM – 6 PM' },
             ].map(item => (
-              <p key={item.v} style={{ fontSize: '0.82rem', color: '#d1d5db', fontFamily: 'Inter, sans-serif' }}>
+              <p key={item.v} style={{ fontSize: '0.82rem', color: '#faf9f5', fontFamily: 'Inter, sans-serif' }}>
                 {item.v}
               </p>
             ))}
@@ -140,7 +140,7 @@ export default function Contact() {
       </div>
 
       {/* ── Right panel — form ────────────────────────────────── */}
-      <div className="contact-right" style={{ backgroundColor: '#FAFAF8', padding: 'clamp(3rem, 6vw, 5rem)', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      <div className="contact-right" style={{ backgroundColor: '#faf9f5', padding: 'clamp(3rem, 6vw, 5rem)', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
 
         {emailStatus === 'success' && (
           <div style={{ marginBottom: '1.5rem', padding: '12px 16px', backgroundColor: 'rgba(22,163,74,0.06)', borderLeft: '3px solid #16a34a', borderRadius: '2px' }}>
@@ -148,45 +148,45 @@ export default function Contact() {
           </div>
         )}
         {emailStatus === 'error' && (
-          <div style={{ marginBottom: '1.5rem', padding: '12px 16px', backgroundColor: 'rgba(193,68,14,0.06)', borderLeft: '3px solid #C1440E', borderRadius: '2px' }}>
-            <p style={{ color: '#C1440E', fontSize: '0.85rem', fontFamily: 'Inter, sans-serif' }}>Failed to send — please WhatsApp or call us directly.</p>
+          <div style={{ marginBottom: '1.5rem', padding: '12px 16px', backgroundColor: 'rgba(204,120,92,0.06)', borderLeft: '3px solid #cc785c', borderRadius: '2px' }}>
+            <p style={{ color: '#cc785c', fontSize: '0.85rem', fontFamily: 'Inter, sans-serif' }}>Failed to send — please WhatsApp or call us directly.</p>
           </div>
         )}
 
         <form ref={formRef} style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
           {/* Name */}
           <div>
-            <label htmlFor="name" style={labelStyle}>Full Name <span style={{ color: '#C1440E' }}>*</span></label>
+            <label htmlFor="name" style={labelStyle}>Full Name <span style={{ color: '#cc785c' }}>*</span></label>
             <input id="name" name="name" type="text" required autoComplete="name" placeholder="Your full name"
               style={inputStyle}
-              onFocus={e => (e.target.style.borderBottomColor = '#C1440E')}
-              onBlur={e  => (e.target.style.borderBottomColor = '#c8c4bc')}
+              onFocus={e => (e.target.style.borderBottomColor = '#cc785c')}
+              onBlur={e  => (e.target.style.borderBottomColor = '#e6dfd8')}
             />
           </div>
 
           {/* Phone */}
           <div>
             <label htmlFor="phone" style={labelStyle}>
-              Phone Number <span style={{ color: '#C1440E' }}>*</span>
+              Phone Number <span style={{ color: '#cc785c' }}>*</span>
               <span style={{ color: '#9ca3af', fontWeight: 400, marginLeft: '6px' }}>— for WhatsApp</span>
             </label>
             <input id="phone" name="phone" type="tel" required autoComplete="tel" placeholder="+91 98765 43210"
               value={phone} onChange={e => setPhone(e.target.value)}
               style={inputStyle}
-              onFocus={e => (e.target.style.borderBottomColor = '#C1440E')}
-              onBlur={e  => (e.target.style.borderBottomColor = '#c8c4bc')}
+              onFocus={e => (e.target.style.borderBottomColor = '#cc785c')}
+              onBlur={e  => (e.target.style.borderBottomColor = '#e6dfd8')}
             />
           </div>
 
           {/* Message */}
           <div>
-            <label htmlFor="message" style={labelStyle}>Your Project <span style={{ color: '#C1440E' }}>*</span></label>
+            <label htmlFor="message" style={labelStyle}>Your Project <span style={{ color: '#cc785c' }}>*</span></label>
             <textarea id="message" name="message" rows="4" required
               placeholder="Briefly describe what you're building — plot size, floors, project type…"
               value={message} onChange={e => setMessage(e.target.value)}
               style={{ ...inputStyle, resize: 'none' }}
-              onFocus={e => (e.target.style.borderBottomColor = '#C1440E')}
-              onBlur={e  => (e.target.style.borderBottomColor = '#c8c4bc')}
+              onFocus={e => (e.target.style.borderBottomColor = '#cc785c')}
+              onBlur={e  => (e.target.style.borderBottomColor = '#e6dfd8')}
             />
           </div>
 
@@ -199,8 +199,8 @@ export default function Contact() {
             <input id="email" name="email" type="email" autoComplete="email" placeholder="you@example.com"
               value={email} onChange={e => setEmail(e.target.value)}
               style={inputStyle}
-              onFocus={e => (e.target.style.borderBottomColor = '#C1440E')}
-              onBlur={e  => (e.target.style.borderBottomColor = '#c8c4bc')}
+              onFocus={e => (e.target.style.borderBottomColor = '#cc785c')}
+              onBlur={e  => (e.target.style.borderBottomColor = '#e6dfd8')}
             />
           </div>
 
@@ -209,18 +209,18 @@ export default function Contact() {
             {/* Primary — WhatsApp */}
             <button onClick={handleWhatsApp} style={{
               width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center',
-              gap: '10px', padding: '16px', borderRadius: '4px', border: 'none',
-              fontSize: '1rem', fontWeight: 700, fontFamily: 'Inter, sans-serif',
+              gap: '10px', padding: '14px', borderRadius: '8px', border: 'none',
+              fontSize: '1rem', fontWeight: 500, fontFamily: 'Inter, sans-serif',
               cursor: whatsappEnabled ? 'pointer' : 'not-allowed',
-              backgroundColor: whatsappEnabled ? '#25D366' : '#e8e4dc',
-              color: whatsappEnabled ? '#fff' : '#bbb',
+              backgroundColor: whatsappEnabled ? '#cc785c' : '#e6dfd8',
+              color: whatsappEnabled ? '#ffffff' : '#6c6a64',
               transition: 'opacity 0.15s',
               marginBottom: '12px',
-              boxShadow: whatsappEnabled ? '0 4px 16px rgba(37,211,102,0.3)' : 'none',
+              boxShadow: 'none',
             }}>
               <FaWhatsapp size={20} /> WhatsApp MSK
             </button>
-            {whatsappHint && <p style={{ fontSize: '0.7rem', color: '#C1440E', marginBottom: '8px', fontFamily: 'Inter, sans-serif' }}>{whatsappHint}</p>}
+            {whatsappHint && <p style={{ fontSize: '0.7rem', color: '#cc785c', marginBottom: '8px', fontFamily: 'Inter, sans-serif' }}>{whatsappHint}</p>}
 
             {/* Secondary — text-style email link */}
             <button onClick={handleEmail} disabled={emailStatus === 'sending'} style={{
@@ -236,7 +236,7 @@ export default function Contact() {
               <HiOutlineMail size={14} />
               {emailStatus === 'sending' ? 'Sending…' : 'or send by email'}
             </button>
-            {emailHint && <p style={{ fontSize: '0.7rem', color: '#C1440E', marginTop: '4px', fontFamily: 'Inter, sans-serif' }}>{emailHint}</p>}
+            {emailHint && <p style={{ fontSize: '0.7rem', color: '#cc785c', marginTop: '4px', fontFamily: 'Inter, sans-serif' }}>{emailHint}</p>}
           </div>
         </form>
       </div>
@@ -254,17 +254,17 @@ export default function Contact() {
       {/* Floating address card */}
       <div className="map-card" style={{
         position: 'absolute', bottom: '2rem', left: '2rem',
-        backgroundColor: '#FAFAF8',
+        backgroundColor: '#faf9f5',
         padding: '1.5rem 2rem',
-        borderRadius: '4px',
-        borderLeft: '3px solid #C1440E',
-        boxShadow: '0 8px 32px rgba(26,23,20,0.14)',
+        borderRadius: '12px',
+        borderLeft: '3px solid #cc785c',
+        boxShadow: '0 8px 32px rgba(20,20,19,0.14)',
         maxWidth: '300px',
       }}>
-        <p style={{ fontSize: '0.58rem', fontWeight: 700, color: '#C1440E', textTransform: 'uppercase', letterSpacing: '0.15em', fontFamily: 'Inter, sans-serif', marginBottom: '0.6rem' }}>
+        <p style={{ fontSize: '0.58rem', fontWeight: 500, color: '#cc785c', textTransform: 'uppercase', letterSpacing: '0.15em', fontFamily: 'Inter, sans-serif', marginBottom: '0.6rem' }}>
           Our Office
         </p>
-        <p style={{ fontSize: '0.88rem', color: '#6b6460', fontFamily: 'Inter, sans-serif', lineHeight: 1.7, marginBottom: '1.25rem' }}>
+        <p style={{ fontSize: '0.88rem', color: '#3d3d3a', fontFamily: 'Inter, sans-serif', lineHeight: 1.7, marginBottom: '1.25rem' }}>
           Pranay Marg, Waddepally,<br />
           Hanamakonda, Telangana 506370
         </p>
@@ -274,7 +274,7 @@ export default function Contact() {
           rel="noopener noreferrer"
           style={{
             display: 'inline-flex', alignItems: 'center', gap: '6px',
-            fontSize: '0.8rem', fontWeight: 700, color: '#C1440E',
+            fontSize: '0.8rem', fontWeight: 500, color: '#cc785c',
             fontFamily: 'Inter, sans-serif', textDecoration: 'none',
             letterSpacing: '0.02em',
           }}

--- a/src/Components/CookieNotice.js
+++ b/src/Components/CookieNotice.js
@@ -16,14 +16,20 @@ const CookieNotice = () => {
   if (!visible) return null;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 border-t border-gray-700 px-6 py-4 flex flex-col sm:flex-row items-center justify-between gap-4">
-      <p className="text-sm text-gray-400 text-center sm:text-left">
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50 px-6 py-4 flex flex-col sm:flex-row items-center justify-between gap-4"
+      style={{ backgroundColor: '#181715', fontFamily: 'Inter, sans-serif' }}
+    >
+      <p className="text-sm text-center sm:text-left" style={{ color: '#a09d96' }}>
         We use cookies and collect enquiry data to improve your experience. By using this site you agree to our{' '}
-        <a href="/privacy" className="text-orange-500 hover:underline">Privacy Policy</a>.
+        <a href="/privacy" className="hover:underline" style={{ color: '#cc785c' }}>Privacy Policy</a>.
       </p>
       <button
         onClick={accept}
-        className="flex-shrink-0 bg-orange-700 hover:bg-orange-600 text-white text-sm font-semibold px-5 py-2 rounded-lg transition-colors"
+        className="flex-shrink-0 text-sm font-medium px-5 py-2 transition-colors"
+        style={{ backgroundColor: '#cc785c', color: '#ffffff', borderRadius: '8px' }}
+        onMouseEnter={e => { e.currentTarget.style.backgroundColor = '#a9583e'; }}
+        onMouseLeave={e => { e.currentTarget.style.backgroundColor = '#cc785c'; }}
       >
         Got it
       </button>

--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -3,7 +3,7 @@ import { FaInstagram, FaWhatsapp } from 'react-icons/fa';
 import { HiOutlineMail } from 'react-icons/hi';
 
 const Footer = () => (
-  <footer style={{ backgroundColor: '#1a1714', borderTop: '3px solid #C1440E' }}>
+  <footer style={{ backgroundColor: '#181715', borderTop: '3px solid #cc785c' }}>
     <div className="max-w-7xl mx-auto px-6 lg:px-14" style={{ paddingTop: '4rem', paddingBottom: '3rem' }}>
 
       <div className="grid md:grid-cols-3 gap-12" style={{ paddingBottom: '3rem', borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
@@ -27,7 +27,7 @@ const Footer = () => (
               <a key={label} href={href} target={href.startsWith('http') ? '_blank' : undefined}
                 rel="noopener noreferrer" aria-label={label}
                 style={{ color: 'rgba(255,255,255,0.3)', transition: 'color 0.2s ease' }}
-                onMouseEnter={e => e.currentTarget.style.color = '#C1440E'}
+                onMouseEnter={e => e.currentTarget.style.color = '#cc785c'}
                 onMouseLeave={e => e.currentTarget.style.color = 'rgba(255,255,255,0.3)'}
               >{icon}</a>
             ))}
@@ -35,7 +35,7 @@ const Footer = () => (
         </div>
 
         <div>
-          <p style={{ fontSize: '0.58rem', color: '#C1440E', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.2em', fontFamily: 'Inter, sans-serif', marginBottom: '1.4rem' }}>Navigation</p>
+          <p style={{ fontSize: '0.58rem', color: '#cc785c', fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.2em', fontFamily: 'Inter, sans-serif', marginBottom: '1.4rem' }}>Navigation</p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
             {['Home', 'Services', 'About', 'Projects', 'Contact'].map(item => (
               <a key={item} href={`#${item.toLowerCase()}`}
@@ -48,7 +48,7 @@ const Footer = () => (
         </div>
 
         <div>
-          <p style={{ fontSize: '0.58rem', color: '#C1440E', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.2em', fontFamily: 'Inter, sans-serif', marginBottom: '1.4rem' }}>Get in Touch</p>
+          <p style={{ fontSize: '0.58rem', color: '#cc785c', fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.2em', fontFamily: 'Inter, sans-serif', marginBottom: '1.4rem' }}>Get in Touch</p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.9rem' }}>
             {[
               { label: 'Phone', val: '+91 99890 90978' },

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -66,22 +66,22 @@ function Header({ onStartProject }) {
               alt="MSK Associates"
               style={{ height: '60px', width: 'auto', display: 'block', transition: 'opacity 0.4s ease' }}
             />
-            <div className="hidden sm:flex flex-col justify-center" style={{ borderLeft: '2px solid #C1440E', paddingLeft: '1rem' }}>
+            <div className="hidden sm:flex flex-col justify-center" style={{ borderLeft: '2px solid #cc785c', paddingLeft: '1rem' }}>
               <span style={{
                 fontFamily: 'Inter, sans-serif', fontSize: '1.2rem', fontWeight: 900,
                 letterSpacing: '0.2em', lineHeight: 1,
-                color: onDark ? '#ffffff' : '#1a1714',
+                color: onDark ? '#ffffff' : '#141413',
                 transition: 'color 0.5s ease',
               }}>
                 MSKASSOCIATES
               </span>
               <span style={{
                 fontFamily: 'Inter, sans-serif', fontSize: '0.6rem', letterSpacing: '0.06em', lineHeight: 1,
-                color: onDark ? 'rgba(255,255,255,0.45)' : '#888',
+                color: onDark ? 'rgba(255,255,255,0.45)' : '#6c6a64',
                 marginTop: '4px',
                 transition: 'color 0.5s ease',
               }}>
-                Structural Engineers <span style={{ color: '#C1440E' }}>·</span> Planners <span style={{ color: '#C1440E' }}>·</span> Builders
+                Structural Engineers <span style={{ color: '#cc785c' }}>·</span> Planners <span style={{ color: '#cc785c' }}>·</span> Builders
               </span>
             </div>
           </a>
@@ -95,7 +95,7 @@ function Header({ onStartProject }) {
                 className={`msk-nav-link relative px-3 py-2 text-sm${activeLink === link.id ? ' active' : ''}`}
                 style={{
                   color: activeLink === link.id
-                    ? '#C1440E'
+                    ? '#cc785c'
                     : onDark ? 'rgba(255,255,255,0.7)' : '#6b7280',
                   fontWeight: activeLink === link.id ? 700 : 500,
                   textDecoration: 'none',
@@ -106,7 +106,7 @@ function Header({ onStartProject }) {
                 {link.label}
                 <span className="msk-underline" style={{
                   position: 'absolute', bottom: '4px', left: '12px', right: '12px',
-                  height: '1.5px', backgroundColor: '#C1440E', display: 'block',
+                  height: '1.5px', backgroundColor: '#cc785c', display: 'block',
                 }} />
               </a>
             ))}
@@ -117,16 +117,16 @@ function Header({ onStartProject }) {
             onClick={onStartProject}
             className="hidden md:inline-flex items-center"
             style={{
-              backgroundColor: '#C1440E', color: '#fff',
-              border: 'none', borderRadius: '3px',
+              backgroundColor: '#cc785c', color: '#fff',
+              border: 'none', borderRadius: '8px',
               padding: '9px 22px',
-              fontSize: '0.65rem', fontWeight: 700,
+              fontSize: '0.65rem', fontWeight: 500,
               fontFamily: 'Inter, sans-serif', letterSpacing: '0.1em',
               textTransform: 'uppercase', cursor: 'pointer',
               transition: 'background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease',
             }}
-            onMouseEnter={e => { e.currentTarget.style.backgroundColor = '#a8390b'; e.currentTarget.style.transform = 'translateY(-1px)'; e.currentTarget.style.boxShadow = '0 6px 20px rgba(193,68,14,0.35)'; }}
-            onMouseLeave={e => { e.currentTarget.style.backgroundColor = '#C1440E'; e.currentTarget.style.transform = ''; e.currentTarget.style.boxShadow = ''; }}
+            onMouseEnter={e => { e.currentTarget.style.backgroundColor = '#a9583e'; e.currentTarget.style.transform = 'translateY(-1px)'; e.currentTarget.style.boxShadow = '0 6px 20px rgba(204,120,92,0.35)'; }}
+            onMouseLeave={e => { e.currentTarget.style.backgroundColor = '#cc785c'; e.currentTarget.style.transform = ''; e.currentTarget.style.boxShadow = ''; }}
           >
             Start a Project
           </button>
@@ -136,10 +136,10 @@ function Header({ onStartProject }) {
             <button
               onClick={onStartProject}
               style={{
-                backgroundColor: '#C1440E', color: '#fff',
-                border: 'none', borderRadius: '3px',
+                backgroundColor: '#cc785c', color: '#fff',
+                border: 'none', borderRadius: '8px',
                 padding: '8px 14px',
-                fontSize: '0.58rem', fontWeight: 700,
+                fontSize: '0.58rem', fontWeight: 500,
                 fontFamily: 'Inter, sans-serif', letterSpacing: '0.09em',
                 textTransform: 'uppercase', cursor: 'pointer',
                 whiteSpace: 'nowrap',
@@ -179,7 +179,7 @@ function Header({ onStartProject }) {
                   transition={{ delay: i * 0.04, duration: 0.18 }}
                   className="block py-3 text-sm font-medium"
                   style={{
-                    color: activeLink === link.id ? '#C1440E' : '#374151',
+                    color: activeLink === link.id ? '#cc785c' : '#374151',
                     fontWeight: activeLink === link.id ? 700 : 500,
                     borderBottom: '1px solid rgba(0,0,0,0.05)',
                     textDecoration: 'none',
@@ -198,9 +198,9 @@ function Header({ onStartProject }) {
                 <button
                   onClick={() => { setMenuOpen(false); if (onStartProject) onStartProject(); }}
                   style={{
-                    width: '100%', backgroundColor: '#C1440E', color: '#fff',
-                    border: 'none', borderRadius: '3px', padding: '13px',
-                    fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.1em',
+                    width: '100%', backgroundColor: '#cc785c', color: '#fff',
+                    border: 'none', borderRadius: '8px', padding: '13px',
+                    fontSize: '0.72rem', fontWeight: 500, letterSpacing: '0.1em',
                     textTransform: 'uppercase', cursor: 'pointer',
                     fontFamily: 'Inter, sans-serif',
                   }}

--- a/src/Components/HeroBanner.js
+++ b/src/Components/HeroBanner.js
@@ -24,7 +24,7 @@ export default function HeroBanner({ onStartProject }) {
   }, [current, tick]);
 
   return (
-    <div style={{ position: 'relative', height: '100svh', minHeight: '620px', overflow: 'hidden', backgroundColor: '#060a10' }}>
+    <div style={{ position: 'relative', height: '100svh', minHeight: '620px', overflow: 'hidden', backgroundColor: '#181715' }}>
 
       <style>{`
         @keyframes kenBurns {
@@ -44,8 +44,8 @@ export default function HeroBanner({ onStartProject }) {
         }
         .hero-btn-primary:hover {
           transform: translateY(-2px);
-          box-shadow: 0 14px 40px rgba(193,68,14,0.45);
-          background-color: #a8390b;
+          box-shadow: 0 14px 40px rgba(204,120,92,0.45);
+          background-color: #a9583e;
         }
         .hero-link { transition: color 0.22s ease; }
         .hero-link:hover { color: #fff !important; }
@@ -83,17 +83,17 @@ export default function HeroBanner({ onStartProject }) {
                   /* Floor plan slide: dark only on left — plan visible on right */
                   <div style={{
                     position: 'absolute', inset: 0, zIndex: 1, pointerEvents: 'none',
-                    background: 'linear-gradient(to right, rgba(4,8,16,0.94) 0%, rgba(4,8,16,0.90) 38%, rgba(4,8,16,0.30) 62%, rgba(4,8,16,0.06) 100%)',
+                    background: 'linear-gradient(to right, rgba(24,23,21,0.94) 0%, rgba(24,23,21,0.90) 38%, rgba(24,23,21,0.30) 62%, rgba(24,23,21,0.06) 100%)',
                   }} />
                 ) : (
                   <>
                     <div style={{
                       position: 'absolute', inset: 0, zIndex: 1, pointerEvents: 'none',
-                      background: 'linear-gradient(110deg, rgba(4,8,16,0.86) 0%, rgba(4,8,16,0.58) 55%, rgba(4,8,16,0.18) 100%)',
+                      background: 'linear-gradient(110deg, rgba(24,23,21,0.86) 0%, rgba(24,23,21,0.58) 55%, rgba(24,23,21,0.18) 100%)',
                     }} />
                     <div style={{
                       position: 'absolute', inset: 0, zIndex: 1, pointerEvents: 'none',
-                      background: 'linear-gradient(to top, rgba(4,8,16,0.82) 0%, rgba(4,8,16,0) 42%)',
+                      background: 'linear-gradient(to top, rgba(24,23,21,0.82) 0%, rgba(24,23,21,0) 42%)',
                     }} />
                   </>
                 )}
@@ -124,7 +124,7 @@ export default function HeroBanner({ onStartProject }) {
             marginBottom: '1.8rem',
           }}
         >
-          <span style={{ display: 'inline-block', width: '26px', height: '1.5px', backgroundColor: '#C1440E', flexShrink: 0 }} />
+          <span style={{ display: 'inline-block', width: '26px', height: '1.5px', backgroundColor: '#cc785c', flexShrink: 0 }} />
           Structural Engineers · Warangal, Telangana
         </motion.p>
 
@@ -135,9 +135,9 @@ export default function HeroBanner({ onStartProject }) {
             animate={{ y: '0%' }}
             transition={{ duration: 0.95, delay: 0.3, ease: [0.16, 1, 0.3, 1] }}
             style={{
-              fontFamily: 'Cormorant Garant, Georgia, serif',
+              fontFamily: 'Cormorant Garamond, Georgia, serif',
               fontSize: 'clamp(2rem, 8vw, 6.8rem)',
-              fontWeight: 700, lineHeight: 0.92,
+              fontWeight: 500, lineHeight: 0.92,
               letterSpacing: '-0.035em', color: '#ffffff', margin: 0,
             }}
           >
@@ -152,9 +152,9 @@ export default function HeroBanner({ onStartProject }) {
             animate={{ y: '0%' }}
             transition={{ duration: 0.95, delay: 0.42, ease: [0.16, 1, 0.3, 1] }}
             style={{
-              fontFamily: 'Cormorant Garant, Georgia, serif',
+              fontFamily: 'Cormorant Garamond, Georgia, serif',
               fontSize: 'clamp(2rem, 8vw, 6.8rem)',
-              fontWeight: 700, lineHeight: 0.92,
+              fontWeight: 500, lineHeight: 0.92,
               letterSpacing: '-0.035em', color: '#ffffff', margin: 0,
             }}
           >
@@ -167,7 +167,7 @@ export default function HeroBanner({ onStartProject }) {
           initial={{ width: 0 }}
           animate={{ width: '48px' }}
           transition={{ duration: 0.5, delay: 0.7, ease: [0.16, 1, 0.3, 1] }}
-          style={{ height: '2px', backgroundColor: '#C1440E', marginBottom: '1.6rem' }}
+          style={{ height: '2px', backgroundColor: '#cc785c', marginBottom: '1.6rem' }}
         />
 
         {/* Sub */}
@@ -228,7 +228,7 @@ export default function HeroBanner({ onStartProject }) {
             <div style={{
               width: i === current ? '32px' : '8px',
               height: '2px', borderRadius: '2px',
-              backgroundColor: i === current ? '#C1440E' : 'rgba(255,255,255,0.28)',
+              backgroundColor: i === current ? '#cc785c' : 'rgba(255,255,255,0.28)',
               transition: 'width 0.4s ease, background-color 0.4s ease',
               position: 'relative', overflow: 'hidden',
             }}>
@@ -237,7 +237,7 @@ export default function HeroBanner({ onStartProject }) {
                   key={`fill-${tick}`}
                   style={{
                     position: 'absolute', left: 0, top: 0, bottom: 0,
-                    backgroundColor: '#C1440E',
+                    backgroundColor: '#cc785c',
                     animation: `progressFill ${DURATION}ms linear forwards`,
                   }}
                 />

--- a/src/Components/MarqueeStrip.js
+++ b/src/Components/MarqueeStrip.js
@@ -12,7 +12,7 @@ const items = [
 ];
 
 const MarqueeStrip = () => (
-  <div style={{ backgroundColor: '#EDEAE3', overflow: 'hidden', padding: '14px 0', borderBottom: '1px solid #d8d4cc' }}>
+  <div style={{ backgroundColor: '#f5f0e8', overflow: 'hidden', padding: '14px 0', borderBottom: '1px solid #e6dfd8' }}>
     <style>{`
       @keyframes mskMarquee {
         0%   { transform: translateX(0); }
@@ -39,7 +39,7 @@ const MarqueeStrip = () => (
               }}>
                 {item}
               </span>
-              <span style={{ color: '#C1440E', fontSize: '0.38rem', opacity: 0.7 }}>◆</span>
+              <span style={{ color: '#cc785c', fontSize: '0.38rem', opacity: 0.7 }}>◆</span>
             </span>
           ))}
         </div>

--- a/src/Components/PhotoGallery.js
+++ b/src/Components/PhotoGallery.js
@@ -92,7 +92,7 @@ export default function PhotoGallery() {
       <style>{`
         .gallery-img { transition: transform 0.6s cubic-bezier(0.16,1,0.3,1); }
         .gallery-cell:hover .gallery-img { transform: scale(1.06); }
-        .gallery-overlay { opacity: 0; transition: opacity 0.3s ease; background: rgba(26,23,20,0.38); }
+        .gallery-overlay { opacity: 0; transition: opacity 0.3s ease; background: rgba(20,20,19,0.38); }
         .gallery-cell:hover .gallery-overlay { opacity: 1; }
       `}</style>
 
@@ -114,7 +114,7 @@ export default function PhotoGallery() {
               overflow: 'hidden',
               cursor: 'pointer',
               position: 'relative',
-              backgroundColor: '#e0dbd2',
+              backgroundColor: '#e6dfd8',
             }}
           >
             <img
@@ -130,7 +130,7 @@ export default function PhotoGallery() {
               display: 'flex', alignItems: 'center', justifyContent: 'center',
             }}>
               <span style={{
-                fontSize: '0.6rem', fontWeight: 700,
+                fontSize: '0.6rem', fontWeight: 500,
                 color: 'rgba(255,255,255,0.9)', letterSpacing: '0.2em',
                 textTransform: 'uppercase', fontFamily: 'Inter, sans-serif',
               }}>View</span>
@@ -144,16 +144,16 @@ export default function PhotoGallery() {
         <button
           onClick={() => openLightbox(0)}
           style={{
-            background: 'none', border: '1px solid #c8c4bc',
+            background: 'none', border: '1px solid #e6dfd8',
             borderRadius: '3px', padding: '11px 28px',
-            fontSize: '0.68rem', fontWeight: 700,
+            fontSize: '0.68rem', fontWeight: 500,
             fontFamily: 'Inter, sans-serif', letterSpacing: '0.1em',
             textTransform: 'uppercase', cursor: 'pointer',
-            color: '#1a1714',
+            color: '#141413',
             transition: 'border-color 0.2s ease, color 0.2s ease',
           }}
-          onMouseEnter={e => { e.currentTarget.style.borderColor = '#C1440E'; e.currentTarget.style.color = '#C1440E'; }}
-          onMouseLeave={e => { e.currentTarget.style.borderColor = '#c8c4bc'; e.currentTarget.style.color = '#1a1714'; }}
+          onMouseEnter={e => { e.currentTarget.style.borderColor = '#cc785c'; e.currentTarget.style.color = '#cc785c'; }}
+          onMouseLeave={e => { e.currentTarget.style.borderColor = '#e6dfd8'; e.currentTarget.style.color = '#141413'; }}
         >
           Browse Projects
         </button>

--- a/src/Components/ProjectGallery.js
+++ b/src/Components/ProjectGallery.js
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import PhotoGallery from './PhotoGallery';
 
 const ProjectGallery = () => (
-  <div style={{ backgroundColor: '#EDEAE3' }}>
+  <div style={{ backgroundColor: '#f5f0e8' }}>
     <div className="max-w-7xl mx-auto px-6 lg:px-14" style={{ paddingTop: '7rem', paddingBottom: '7rem' }}>
 
       <motion.div
@@ -15,23 +15,23 @@ const ProjectGallery = () => (
       >
         <p style={{
           display: 'flex', alignItems: 'center', gap: '0.8rem',
-          fontSize: '0.58rem', color: '#C1440E', fontWeight: 700,
+          fontSize: '0.58rem', color: '#cc785c', fontWeight: 500,
           textTransform: 'uppercase', letterSpacing: '0.22em',
           fontFamily: 'Inter, sans-serif', marginBottom: '1.4rem',
         }}>
-          <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#C1440E' }} />
+          <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#cc785c' }} />
           Our Work
         </p>
         <h2 style={{
-          fontFamily: 'Cormorant Garant, Georgia, serif',
+          fontFamily: 'Cormorant Garamond, Georgia, serif',
           fontSize: 'clamp(2.4rem, 4.5vw, 3.6rem)',
-          fontWeight: 700, lineHeight: 1.0,
-          letterSpacing: '-0.025em', color: '#1a1714',
+          fontWeight: 500, lineHeight: 1.0,
+          letterSpacing: '-0.025em', color: '#141413',
           margin: '0 0 1rem',
         }}>
           A Portfolio of Precision
         </h2>
-        <p style={{ color: '#888', fontSize: '0.92rem', lineHeight: 1.7, maxWidth: '440px', fontFamily: 'Inter, sans-serif' }}>
+        <p style={{ color: '#6c6a64', fontSize: '0.92rem', lineHeight: 1.7, maxWidth: '440px', fontFamily: 'Inter, sans-serif' }}>
           Hundreds of projects across Telangana — each one stamped, calculated, and site-supervised by MSK.
         </p>
       </motion.div>

--- a/src/Components/ProjectScopeBuilder.js
+++ b/src/Components/ProjectScopeBuilder.js
@@ -89,9 +89,9 @@ function Pill({ label, selected, onClick }) {
         padding: '9px 16px', borderRadius: '4px', cursor: 'pointer',
         fontFamily: 'Inter', fontSize: '0.85rem', fontWeight: 600,
         transition: 'all 0.15s', whiteSpace: 'nowrap',
-        border: selected ? '2px solid #C1440E' : '1px solid #d1d5db',
-        backgroundColor: selected ? 'rgba(193,68,14,0.07)' : 'white',
-        color: selected ? '#C1440E' : '#374151',
+        border: selected ? '2px solid #cc785c' : '1px solid #d1d5db',
+        backgroundColor: selected ? 'rgba(204,120,92,0.07)' : 'white',
+        color: selected ? '#cc785c' : '#374151',
       }}
     >
       {label}
@@ -107,7 +107,7 @@ function ProgressBar({ step }) {
     <div style={{ marginBottom: '2.5rem' }}>
       <div style={{ display: 'flex', gap: 0, marginBottom: '8px' }}>
         {[0, 1, 2].map(i => (
-          <div key={i} style={{ flex: 1, height: '3px', backgroundColor: i < current ? '#C1440E' : '#e5e7eb', marginRight: i < 2 ? '3px' : 0, borderRadius: '2px', transition: 'background-color 0.3s' }} />
+          <div key={i} style={{ flex: 1, height: '3px', backgroundColor: i < current ? '#cc785c' : '#e5e7eb', marginRight: i < 2 ? '3px' : 0, borderRadius: '2px', transition: 'background-color 0.3s' }} />
         ))}
       </div>
       <p style={{ fontSize: '0.65rem', color: '#9ca3af', fontFamily: 'Inter', textTransform: 'uppercase', letterSpacing: '0.1em' }}>
@@ -136,7 +136,7 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
   const result = step === 'result' ? buildResult(type, contractor, timeline) : null;
 
   const labelStyle = {
-    fontSize: '0.62rem', fontWeight: 700, color: '#374151',
+    fontSize: '0.62rem', fontWeight: 500, color: '#374151',
     textTransform: 'uppercase', letterSpacing: '0.12em', fontFamily: 'Inter',
     marginBottom: '0.75rem', display: 'block',
   };
@@ -147,10 +147,10 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
       {/* Section heading — hidden when used inside modal */}
       {showHeading && (
         <div className="mb-12" data-aos="fade-up">
-          <p style={{ fontSize: '0.7rem', color: '#C1440E', letterSpacing: '0.15em', textTransform: 'uppercase', fontWeight: 700, fontFamily: 'Inter', marginBottom: '0.75rem' }}>
+          <p style={{ fontSize: '0.7rem', color: '#cc785c', letterSpacing: '0.15em', textTransform: 'uppercase', fontWeight: 500, fontFamily: 'Inter', marginBottom: '0.75rem' }}>
             Project Planner
           </p>
-          <h2 style={{ fontSize: 'clamp(2rem, 4vw, 3rem)', color: '#0F2040', lineHeight: 1.1, fontFamily: 'Cormorant Garant, Georgia, serif', fontWeight: 800, marginBottom: '0.75rem' }}>
+          <h2 style={{ fontSize: 'clamp(2rem, 4vw, 3rem)', color: '#141413', lineHeight: 1.1, fontFamily: 'Cormorant Garamond, Georgia, serif', fontWeight: 500, marginBottom: '0.75rem' }}>
             What does your project need?
           </h2>
           <p style={{ color: '#6b7280', fontSize: '0.95rem', lineHeight: 1.7, maxWidth: '480px' }}>
@@ -175,7 +175,7 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
         {/* ── Step 1: project type ─────────────────────────────────────── */}
         {step === 1 && (
           <div>
-            <p style={{ fontSize: '1.1rem', fontWeight: 700, color: '#0F2040', fontFamily: 'Inter', marginBottom: '1.5rem' }}>
+            <p style={{ fontSize: '1.1rem', fontWeight: 500, color: '#141413', fontFamily: 'Inter', marginBottom: '1.5rem' }}>
               What are you planning to build?
             </p>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '12px' }}>
@@ -186,14 +186,14 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
                   style={{
                     padding: '18px 16px', borderRadius: '4px', cursor: 'pointer',
                     textAlign: 'left', fontFamily: 'Inter', transition: 'all 0.15s',
-                    border: type === pt.id ? '2px solid #C1440E' : '1px solid #e5e7eb',
-                    backgroundColor: type === pt.id ? 'rgba(193,68,14,0.05)' : '#fafafa',
+                    border: type === pt.id ? '2px solid #cc785c' : '1px solid #e5e7eb',
+                    backgroundColor: type === pt.id ? 'rgba(204,120,92,0.05)' : '#fafafa',
                   }}
                 >
-                  <span style={{ display: 'block', fontSize: '0.6rem', fontWeight: 700, color: type === pt.id ? '#C1440E' : '#d1d5db', letterSpacing: '0.12em', marginBottom: '8px', fontFamily: 'Inter' }}>
+                  <span style={{ display: 'block', fontSize: '0.6rem', fontWeight: 500, color: type === pt.id ? '#cc785c' : '#d1d5db', letterSpacing: '0.12em', marginBottom: '8px', fontFamily: 'Inter' }}>
                     {pt.num}
                   </span>
-                  <span style={{ display: 'block', fontSize: '0.92rem', fontWeight: 700, color: type === pt.id ? '#C1440E' : '#0F2040', marginBottom: '4px' }}>
+                  <span style={{ display: 'block', fontSize: '0.92rem', fontWeight: 500, color: type === pt.id ? '#cc785c' : '#141413', marginBottom: '4px' }}>
                     {pt.label}
                   </span>
                   <span style={{ display: 'block', fontSize: '0.72rem', color: '#9ca3af' }}>
@@ -210,11 +210,11 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
           <div>
             <style>{`
               .msk-slider { -webkit-appearance: none; width: 100%; height: 4px; border-radius: 2px; background: #e5e7eb; outline: none; cursor: pointer; }
-              .msk-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 20px; height: 20px; border-radius: 50%; background: #C1440E; cursor: pointer; border: 2px solid white; box-shadow: 0 1px 6px rgba(193,68,14,0.45); }
-              .msk-slider::-moz-range-thumb { width: 20px; height: 20px; border-radius: 50%; background: #C1440E; cursor: pointer; border: 2px solid white; box-shadow: 0 1px 6px rgba(193,68,14,0.45); border: none; }
+              .msk-slider::-webkit-slider-thumb { -webkit-appearance: none; width: 20px; height: 20px; border-radius: 50%; background: #cc785c; cursor: pointer; border: 2px solid white; box-shadow: 0 1px 6px rgba(204,120,92,0.45); }
+              .msk-slider::-moz-range-thumb { width: 20px; height: 20px; border-radius: 50%; background: #cc785c; cursor: pointer; border: 2px solid white; box-shadow: 0 1px 6px rgba(204,120,92,0.45); border: none; }
             `}</style>
 
-            <p style={{ fontSize: '1.1rem', fontWeight: 700, color: '#0F2040', fontFamily: 'Inter', marginBottom: '1.75rem' }}>
+            <p style={{ fontSize: '1.1rem', fontWeight: 500, color: '#141413', fontFamily: 'Inter', marginBottom: '1.75rem' }}>
               Tell us about the plot and height.
             </p>
 
@@ -222,7 +222,7 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
             <div style={{ marginBottom: '1.75rem' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '10px' }}>
                 <span style={labelStyle}>Plot width</span>
-                <span style={{ fontSize: '1rem', fontWeight: 800, color: '#C1440E', fontFamily: 'Inter' }}>{plotW} ft</span>
+                <span style={{ fontSize: '1rem', fontWeight: 500, color: '#cc785c', fontFamily: 'Inter' }}>{plotW} ft</span>
               </div>
               <input type="range" className="msk-slider" min="15" max="120" step="5"
                 value={plotW} onChange={e => setPlotW(Number(e.target.value))} />
@@ -236,7 +236,7 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
             <div style={{ marginBottom: '1.75rem' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '10px' }}>
                 <span style={labelStyle}>Plot depth</span>
-                <span style={{ fontSize: '1rem', fontWeight: 800, color: '#C1440E', fontFamily: 'Inter' }}>{plotD} ft</span>
+                <span style={{ fontSize: '1rem', fontWeight: 500, color: '#cc785c', fontFamily: 'Inter' }}>{plotD} ft</span>
               </div>
               <input type="range" className="msk-slider" min="20" max="200" step="5"
                 value={plotD} onChange={e => setPlotD(Number(e.target.value))} />
@@ -247,20 +247,20 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
             </div>
 
             {/* Live area badge */}
-            <div style={{ backgroundColor: 'rgba(193,68,14,0.06)', border: '1px solid rgba(193,68,14,0.18)', borderRadius: '4px', padding: '8px 14px', marginBottom: '1.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <span style={{ fontSize: '0.82rem', fontWeight: 700, color: '#0F2040', fontFamily: 'Inter' }}>{plotW} × {plotD} ft</span>
-              <span style={{ fontSize: '0.8rem', color: '#C1440E', fontFamily: 'Inter', fontWeight: 600 }}>≈ {sqYd} sq yd</span>
+            <div style={{ backgroundColor: 'rgba(204,120,92,0.06)', border: '1px solid rgba(204,120,92,0.18)', borderRadius: '4px', padding: '8px 14px', marginBottom: '1.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span style={{ fontSize: '0.82rem', fontWeight: 500, color: '#141413', fontFamily: 'Inter' }}>{plotW} × {plotD} ft</span>
+              <span style={{ fontSize: '0.8rem', color: '#cc785c', fontFamily: 'Inter', fontWeight: 600 }}>≈ {sqYd} sq yd</span>
             </div>
 
             {/* Floors — advisory callout */}
             <div style={{
               backgroundColor: '#FFF8F5',
               border: '1px solid #f0d5c8',
-              borderLeft: '3px solid #C1440E',
+              borderLeft: '3px solid #cc785c',
               borderRadius: '6px',
               padding: '1rem 1.2rem',
             }}>
-              <p style={{ fontSize: '0.78rem', fontWeight: 700, color: '#C1440E', fontFamily: 'Inter', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+              <p style={{ fontSize: '0.78rem', fontWeight: 500, color: '#cc785c', fontFamily: 'Inter', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>
                 How many floors?
               </p>
               <p style={{ fontSize: '0.88rem', color: '#4b5563', fontFamily: 'Inter', lineHeight: 1.65, margin: 0 }}>
@@ -273,7 +273,7 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
         {/* ── Step 3: situation ────────────────────────────────────────── */}
         {step === 3 && (
           <div>
-            <p style={{ fontSize: '1.1rem', fontWeight: 700, color: '#0F2040', fontFamily: 'Inter', marginBottom: '1.75rem' }}>
+            <p style={{ fontSize: '1.1rem', fontWeight: 500, color: '#141413', fontFamily: 'Inter', marginBottom: '1.75rem' }}>
               A couple more things.
             </p>
 
@@ -302,7 +302,7 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
         {/* ── Result ───────────────────────────────────────────────────── */}
         {step === 'result' && result && (
           <div>
-            <p style={{ fontSize: '1.05rem', fontWeight: 700, color: '#0F2040', fontFamily: 'Inter', marginBottom: '0.4rem' }}>
+            <p style={{ fontSize: '1.05rem', fontWeight: 500, color: '#141413', fontFamily: 'Inter', marginBottom: '0.4rem' }}>
               For your {TYPE_LABEL[type]}, here's what you need:
             </p>
             <p style={{ fontSize: '0.8rem', color: '#9ca3af', fontFamily: 'Inter', marginBottom: '1.75rem' }}>
@@ -313,11 +313,11 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
             <div style={{ marginBottom: '1.5rem' }}>
               {result.items.map((item, i) => (
                 <div key={i} style={{ display: 'flex', gap: '12px', marginBottom: '1rem', paddingBottom: '1rem', borderBottom: i < result.items.length - 1 ? '1px solid #f3f4f6' : 'none' }}>
-                  <div style={{ width: '22px', height: '22px', borderRadius: '50%', backgroundColor: '#C1440E', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: '2px' }}>
+                  <div style={{ width: '22px', height: '22px', borderRadius: '50%', backgroundColor: '#cc785c', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: '2px' }}>
                     <HiCheck style={{ color: 'white', fontSize: '12px' }} />
                   </div>
                   <div>
-                    <p style={{ fontWeight: 700, color: '#0F2040', fontSize: '0.88rem', fontFamily: 'Inter', marginBottom: '2px' }}>{item.text}</p>
+                    <p style={{ fontWeight: 500, color: '#141413', fontSize: '0.88rem', fontFamily: 'Inter', marginBottom: '2px' }}>{item.text}</p>
                     <p style={{ color: '#6b7280', fontSize: '0.78rem', fontFamily: 'Inter', lineHeight: 1.6 }}>{item.note}</p>
                   </div>
                 </div>
@@ -326,20 +326,20 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
 
             {/* Contractor soft note */}
             {result.contractorNote && (
-              <div style={{ backgroundColor: 'rgba(193,68,14,0.05)', border: '1px solid rgba(193,68,14,0.15)', borderRadius: '4px', padding: '10px 14px', marginBottom: '1.5rem' }}>
-                <p style={{ fontSize: '0.78rem', color: '#C1440E', fontFamily: 'Inter', lineHeight: 1.6 }}>
+              <div style={{ backgroundColor: 'rgba(204,120,92,0.05)', border: '1px solid rgba(204,120,92,0.15)', borderRadius: '4px', padding: '10px 14px', marginBottom: '1.5rem' }}>
+                <p style={{ fontSize: '0.78rem', color: '#cc785c', fontFamily: 'Inter', lineHeight: 1.6 }}>
                   {result.contractorNote}
                 </p>
               </div>
             )}
 
             {/* Timeline card */}
-            <div style={{ backgroundColor: '#f9fafb', borderRadius: '4px', padding: '1rem 1.25rem', marginBottom: '1.5rem', borderLeft: '3px solid #C1440E', display: 'flex', gap: '1.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+            <div style={{ backgroundColor: '#f9fafb', borderRadius: '4px', padding: '1rem 1.25rem', marginBottom: '1.5rem', borderLeft: '3px solid #cc785c', display: 'flex', gap: '1.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
               <div>
-                <p style={{ fontSize: '0.6rem', fontWeight: 700, color: '#9ca3af', fontFamily: 'Inter', textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: '3px' }}>
+                <p style={{ fontSize: '0.6rem', fontWeight: 500, color: '#9ca3af', fontFamily: 'Inter', textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: '3px' }}>
                   Drawings ready in
                 </p>
-                <p style={{ fontSize: '1.3rem', fontWeight: 800, color: '#0F2040', fontFamily: 'Inter', lineHeight: 1 }}>
+                <p style={{ fontSize: '1.3rem', fontWeight: 500, color: '#141413', fontFamily: 'Inter', lineHeight: 1 }}>
                   {result.drawingTime}
                 </p>
               </div>
@@ -377,7 +377,7 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
                       display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '10px',
                       backgroundColor: '#25D366', color: '#fff',
                       padding: '0.9rem', borderRadius: '4px',
-                      fontSize: '0.95rem', fontWeight: 700, fontFamily: 'Inter',
+                      fontSize: '0.95rem', fontWeight: 500, fontFamily: 'Inter',
                       textDecoration: 'none', marginBottom: '10px',
                       boxShadow: '0 4px 14px rgba(37,211,102,0.3)',
                     }}
@@ -428,10 +428,10 @@ export default function ProjectScopeBuilder({ showHeading = true, onComplete }) 
               disabled={!canNext}
               style={{
                 padding: '0.7rem 1.75rem', borderRadius: '4px',
-                fontSize: '0.88rem', fontWeight: 700, fontFamily: 'Inter',
+                fontSize: '0.88rem', fontWeight: 500, fontFamily: 'Inter',
                 cursor: canNext ? 'pointer' : 'not-allowed',
                 border: 'none', transition: 'all 0.15s',
-                backgroundColor: canNext ? '#C1440E' : '#e5e7eb',
+                backgroundColor: canNext ? '#cc785c' : '#e5e7eb',
                 color: canNext ? '#fff' : '#9ca3af',
               }}
             >

--- a/src/Components/Testimonials.js
+++ b/src/Components/Testimonials.js
@@ -59,7 +59,7 @@ export default function Testimonials() {
   const t = testimonials[active];
 
   return (
-    <div style={{ backgroundColor: '#FAFAF8', borderTop: '1px solid #e0dbd2' }}>
+    <div style={{ backgroundColor: '#faf9f5', borderTop: '1px solid #e6dfd8' }}>
       <div
         className="max-w-7xl mx-auto px-6 lg:px-14"
         style={{ paddingTop: 'clamp(4rem, 8vw, 7rem)', paddingBottom: 'clamp(4rem, 8vw, 7rem)' }}
@@ -72,12 +72,12 @@ export default function Testimonials() {
           transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
           style={{
             display: 'flex', alignItems: 'center', gap: '0.8rem',
-            fontSize: '0.58rem', color: '#C1440E', fontWeight: 700,
+            fontSize: '0.58rem', color: '#cc785c', fontWeight: 500,
             textTransform: 'uppercase', letterSpacing: '0.22em',
             fontFamily: 'Inter, sans-serif', marginBottom: 'clamp(3rem, 6vw, 5rem)',
           }}
         >
-          <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#C1440E' }} />
+          <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#cc785c' }} />
           Client Feedback
         </motion.p>
 
@@ -92,12 +92,12 @@ export default function Testimonials() {
               transition={{ duration: 0.55, ease: [0.16, 1, 0.3, 1] }}
             >
               <p style={{
-                fontFamily: 'Cormorant Garant, Georgia, serif',
+                fontFamily: 'Cormorant Garamond, Georgia, serif',
                 fontSize: 'clamp(1rem, 2vw, 1.5rem)',
                 fontStyle: 'italic',
                 lineHeight: 1.45,
                 letterSpacing: '-0.01em',
-                color: '#1a1714',
+                color: '#141413',
                 maxWidth: '860px',
                 marginBottom: 'clamp(2rem, 4vw, 3rem)',
               }}>
@@ -105,10 +105,10 @@ export default function Testimonials() {
               </p>
 
               <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-                <div style={{ width: '28px', height: '2px', backgroundColor: '#C1440E', flexShrink: 0 }} />
+                <div style={{ width: '28px', height: '2px', backgroundColor: '#cc785c', flexShrink: 0 }} />
                 <div>
                   <p style={{
-                    fontWeight: 700, color: '#1a1714',
+                    fontWeight: 500, color: '#141413',
                     fontSize: '0.88rem', fontFamily: 'Inter, sans-serif',
                   }}>{t.name}</p>
                   <p style={{
@@ -139,7 +139,7 @@ export default function Testimonials() {
                 height: '2px',
                 width: i === active ? '36px' : '16px',
                 borderRadius: '2px',
-                backgroundColor: i === active ? '#C1440E' : '#d0cbc2',
+                backgroundColor: i === active ? '#cc785c' : '#e6dfd8',
                 transition: 'width 0.4s ease, background-color 0.3s ease',
               }} />
             </button>

--- a/src/Components/WhatWeDo.js
+++ b/src/Components/WhatWeDo.js
@@ -52,7 +52,7 @@ export default function WhatWeDo() {
   const [open, setOpen] = useState('structural');
 
   return (
-    <div style={{ backgroundColor: '#FAFAF8', borderTop: '1px solid #e0dbd2' }}>
+    <div style={{ backgroundColor: '#faf9f5', borderTop: '1px solid #e6dfd8' }}>
       <style>{`
         @media (max-width: 768px) {
           .wwd-panel { grid-template-columns: 1fr !important; }
@@ -75,25 +75,25 @@ export default function WhatWeDo() {
         >
           <p style={{
             display: 'flex', alignItems: 'center', gap: '0.8rem',
-            fontSize: '0.58rem', color: '#C1440E', fontWeight: 700,
+            fontSize: '0.58rem', color: '#cc785c', fontWeight: 500,
             textTransform: 'uppercase', letterSpacing: '0.22em',
             fontFamily: 'Inter, sans-serif', marginBottom: '1.2rem',
           }}>
-            <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#C1440E' }} />
+            <span style={{ display: 'inline-block', width: '24px', height: '2px', backgroundColor: '#cc785c' }} />
             What We Do
           </p>
           <h2 style={{
-            fontFamily: 'Cormorant Garant, Georgia, serif',
+            fontFamily: 'Cormorant Garamond, Georgia, serif',
             fontSize: 'clamp(2.4rem, 4.5vw, 3.6rem)',
-            fontWeight: 700, lineHeight: 1.0,
-            letterSpacing: '-0.025em', color: '#1a1714', margin: 0,
+            fontWeight: 500, lineHeight: 1.0,
+            letterSpacing: '-0.025em', color: '#141413', margin: 0,
           }}>
             Four disciplines.<br />One team.
           </h2>
         </motion.div>
 
         {/* Accordion */}
-        <div style={{ borderTop: '1px solid #e0dbd2' }}>
+        <div style={{ borderTop: '1px solid #e6dfd8' }}>
           {services.map((s, idx) => {
             const isOpen = open === s.id;
             return (
@@ -103,7 +103,7 @@ export default function WhatWeDo() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.1 }}
                 transition={{ duration: 0.5, delay: idx * 0.08, ease: [0.16, 1, 0.3, 1] }}
-                style={{ borderBottom: '1px solid #e0dbd2' }}
+                style={{ borderBottom: '1px solid #e6dfd8' }}
               >
                 {/* Row trigger */}
                 <button
@@ -118,8 +118,8 @@ export default function WhatWeDo() {
                 >
                   <div style={{ display: 'flex', alignItems: 'center', gap: 'clamp(1rem, 3vw, 2.5rem)' }}>
                     <span style={{
-                      fontSize: '0.55rem', fontWeight: 700,
-                      color: isOpen ? '#C1440E' : '#b0a89e',
+                      fontSize: '0.55rem', fontWeight: 500,
+                      color: isOpen ? '#cc785c' : '#8e8b82',
                       fontFamily: 'Inter, sans-serif', letterSpacing: '0.18em',
                       transition: 'color 0.3s ease', flexShrink: 0,
                     }}>{s.num}</span>
@@ -128,15 +128,15 @@ export default function WhatWeDo() {
                     <span style={{
                       display: 'inline-block',
                       width: isOpen ? '28px' : '0px', height: '2px',
-                      backgroundColor: '#C1440E', flexShrink: 0,
+                      backgroundColor: '#cc785c', flexShrink: 0,
                       transition: 'width 0.35s ease',
                     }} />
 
                     <span className="wwd-title" style={{
-                      fontFamily: 'Cormorant Garant, Georgia, serif',
+                      fontFamily: 'Cormorant Garamond, Georgia, serif',
                       fontSize: 'clamp(1.5rem, 3.5vw, 2.4rem)',
-                      fontWeight: 700, letterSpacing: '-0.025em',
-                      color: isOpen ? '#1a1714' : '#6b6460',
+                      fontWeight: 500, letterSpacing: '-0.025em',
+                      color: isOpen ? '#141413' : '#3d3d3a',
                       transition: 'color 0.3s ease',
                       lineHeight: 1,
                     }}>{s.title}</span>
@@ -146,7 +146,7 @@ export default function WhatWeDo() {
                   <span style={{
                     fontSize: 'clamp(1.2rem, 2.5vw, 1.6rem)',
                     fontWeight: 300,
-                    color: isOpen ? '#C1440E' : '#b0a89e',
+                    color: isOpen ? '#cc785c' : '#8e8b82',
                     transition: 'color 0.3s ease, transform 0.4s ease',
                     transform: isOpen ? 'rotate(45deg)' : 'rotate(0deg)',
                     display: 'inline-block', lineHeight: 1,
@@ -192,9 +192,9 @@ export default function WhatWeDo() {
                           animate={{ opacity: 1, scale: 1 }}
                           transition={{ duration: 0.65, delay: 0.18, ease: [0.16, 1, 0.3, 1] }}
                           style={{
-                            borderRadius: '4px', overflow: 'hidden',
+                            borderRadius: '12px', overflow: 'hidden',
                             aspectRatio: '16 / 9', position: 'relative',
-                            boxShadow: '0 16px 56px rgba(26,23,20,0.1)',
+                            boxShadow: '0 16px 56px rgba(20,20,19,0.1)',
                           }}
                         >
                           <img
@@ -209,7 +209,7 @@ export default function WhatWeDo() {
                           />
                           <div style={{
                             position: 'absolute', bottom: 0, left: 0, right: 0,
-                            height: '3px', backgroundColor: '#C1440E',
+                            height: '3px', backgroundColor: '#cc785c',
                           }} />
                         </motion.div>
 
@@ -224,18 +224,18 @@ export default function WhatWeDo() {
                           }}
                         >
                           <h3 style={{
-                            fontFamily: 'Cormorant Garant, Georgia, serif',
+                            fontFamily: 'Cormorant Garamond, Georgia, serif',
                             fontSize: 'clamp(1.8rem, 3vw, 2.8rem)',
-                            fontWeight: 700, lineHeight: 0.96,
-                            letterSpacing: '-0.03em', color: '#1a1714',
+                            fontWeight: 500, lineHeight: 0.96,
+                            letterSpacing: '-0.03em', color: '#141413',
                             margin: '0 0 1.6rem',
                             whiteSpace: 'pre-line',
                           }}>{`${s.line1}\n${s.line2}`}</h3>
 
-                          <div style={{ width: '36px', height: '2px', backgroundColor: '#C1440E', marginBottom: '1.4rem' }} />
+                          <div style={{ width: '36px', height: '2px', backgroundColor: '#cc785c', marginBottom: '1.4rem' }} />
 
                           <p style={{
-                            color: '#6b6460', lineHeight: 1.88,
+                            color: '#3d3d3a', lineHeight: 1.88,
                             fontSize: 'clamp(0.82rem, 1.2vw, 0.92rem)',
                             fontFamily: 'Inter, sans-serif',
                           }}>{s.body}</p>

--- a/src/Components/WhatsAppFloat.js
+++ b/src/Components/WhatsAppFloat.js
@@ -46,16 +46,16 @@ const WhatsAppFloat = () => {
         style={{
           position: 'relative',
           width: '52px', height: '52px',
-          backgroundColor: '#1a1714',
+          backgroundColor: '#141413',
           borderRadius: '50%',
           border: 'none', cursor: 'pointer',
           display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow: '0 8px 28px rgba(26,23,20,0.32)',
+          boxShadow: '0 8px 28px rgba(20,20,19,0.32)',
           color: '#fff',
           transition: 'transform 0.22s ease, box-shadow 0.22s ease',
         }}
-        onMouseEnter={e => { e.currentTarget.style.transform = 'scale(1.08)'; e.currentTarget.style.boxShadow = '0 12px 36px rgba(26,23,20,0.42)'; }}
-        onMouseLeave={e => { e.currentTarget.style.transform = ''; e.currentTarget.style.boxShadow = '0 8px 28px rgba(26,23,20,0.32)'; }}
+        onMouseEnter={e => { e.currentTarget.style.transform = 'scale(1.08)'; e.currentTarget.style.boxShadow = '0 12px 36px rgba(20,20,19,0.42)'; }}
+        onMouseLeave={e => { e.currentTarget.style.transform = ''; e.currentTarget.style.boxShadow = '0 8px 28px rgba(20,20,19,0.32)'; }}
       >
         <FaWhatsapp size={22} />
       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 :root {
-  --primary-color: #0F2040; /* dark navy */
-  --accent-color: #C1440E; /* terracotta */
-  --light-bg: #EDEAE3;
+  --primary-color: #141413; /* warm ink */
+  --accent-color: #cc785c; /* Anthropic coral */
+  --light-bg: #f5f0e8;
 }
 
 * {
@@ -20,15 +20,15 @@ body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #EDEAE3;
-  color: #1a1714;
+  background-color: #faf9f5;
+  color: #141413;
   font-size: 16px;
   line-height: 1.6;
   overflow-x: hidden;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'Cormorant Garant', Georgia, serif;
+  font-family: 'Cormorant Garamond', Georgia, serif;
   color: var(--primary-color);
 }
 
@@ -41,7 +41,7 @@ a {
   background-color: var(--accent-color);
   color: #fff;
   padding: 0.75rem 1.5rem;
-  border-radius: 4px;
+  border-radius: 8px;
   text-decoration: none;
   transition: transform 0.2s, box-shadow 0.2s;
 }
@@ -56,7 +56,7 @@ a {
 }
 .btn-primary:hover {
   transform: translateY(-2px) !important;
-  box-shadow: 0 8px 24px rgba(193, 68, 14, 0.38) !important;
+  box-shadow: 0 8px 24px rgba(204, 120, 92, 0.38) !important;
 }
 
 .btn-outline {
@@ -120,7 +120,7 @@ input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
 textarea:-webkit-autofill {
-  -webkit-box-shadow: 0 0 0px 1000px #f3f4f6 inset !important;
+  -webkit-box-shadow: 0 0 0px 1000px #faf9f5 inset !important;
   -webkit-text-fill-color: #111827 !important;
   caret-color: #111827;
 }


### PR DESCRIPTION
…TAs, serif editorial headlines

Token-only restyle per DESIGN-claude.md; layout untouched.

- Palette: #faf9f5 warm cream canvas, #141413 warm ink, #cc785c Anthropic coral for CTAs/accents (#a9583e active), #e6dfd8 hairlines, #f5f0e8 soft surface bands, #181715 dark surfaces (footer, contact panel, hero base)
- Typography: Cormorant Garamond (documented Copernicus substitute) for display headlines at weight 500, Inter body; display weights dropped from 700/800 to 500 — the system never bolds serif display
- Buttons: 8px radius coral primary with white text; disabled state uses #e6dfd8 primary-disabled token (WhatsApp CTA now coral)
- Cards: 12px radius on photos, quote card, map card
- CookieNotice: dark #181715 consent card with coral button per spec
- Contact left panel: on-dark text tokens (#faf9f5 / #a09d96)